### PR TITLE
Html 注解支持获取外部Html内容

### DIFF
--- a/src/main/java/com/geccocrawler/gecco/annotation/Html.java
+++ b/src/main/java/com/geccocrawler/gecco/annotation/Html.java
@@ -16,5 +16,16 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Html {
-
+	/**
+	 * 是否取外部Html，默认为false
+	 * 
+	 * <pre>
+	 *  true  - 取外部HTML内容
+	 *  false - 取内容HTML内容（默认）
+	 * </pre>
+	 * 
+	 * @author LiuJunGuang
+	 * @return
+	 */
+	public boolean isOuter() default false;
 }

--- a/src/main/java/com/geccocrawler/gecco/spider/render/html/HtmlParser.java
+++ b/src/main/java/com/geccocrawler/gecco/spider/render/html/HtmlParser.java
@@ -17,6 +17,7 @@ import org.jsoup.select.Elements;
 
 import com.geccocrawler.gecco.annotation.Attr;
 import com.geccocrawler.gecco.annotation.Href;
+import com.geccocrawler.gecco.annotation.Html;
 import com.geccocrawler.gecco.annotation.Image;
 import com.geccocrawler.gecco.annotation.Text;
 import com.geccocrawler.gecco.request.HttpRequest;
@@ -31,101 +32,106 @@ import com.geccocrawler.gecco.spider.render.RenderType;
 import com.geccocrawler.gecco.utils.DownloadImage;
 
 public class HtmlParser {
-	
+
 	private Log log;
-	
+
 	private Document document;
-	
+
 	private String baseUri;
-	
+
 	public HtmlParser(String baseUri, String content) {
 		long beginTime = System.currentTimeMillis();
 		log = LogFactory.getLog(HtmlParser.class);
 		this.baseUri = baseUri;
-		if(isTable(content)) {
+		if (isTable(content)) {
 			this.document = Jsoup.parse(content, baseUri, Parser.xmlParser());
 		} else {
 			this.document = Jsoup.parse(content, baseUri);
 		}
 		long endTime = System.currentTimeMillis();
-		if(log.isTraceEnabled()) {
+		if (log.isTraceEnabled()) {
 			log.trace("init html parser : " + (endTime - beginTime) + "ms");
 		}
 	}
-	
+
 	public String baseUri() {
 		return baseUri;
 	}
-	
+
 	public Object $basic(String selector, Field field) throws Exception {
-		if(field.isAnnotationPresent(Text.class)) {//@Text
+		if (field.isAnnotationPresent(Text.class)) {// @Text
 			Text text = field.getAnnotation(Text.class);
 			String value = $text(selector, text.own());
 			return Conversion.getValue(field.getType(), value);
-		} else if(field.isAnnotationPresent(Image.class)) {//@Image
+		} else if (field.isAnnotationPresent(Image.class)) {// @Image
 			Image image = field.getAnnotation(Image.class);
 			String imageSrc = $image(selector, image.value());
 			String localPath = DownloadImage.download(image.download(), imageSrc);
-			if(StringUtils.isNotEmpty(localPath)) {
+			if (StringUtils.isNotEmpty(localPath)) {
 				return localPath;
 			}
 			return imageSrc;
-		} else if(field.isAnnotationPresent(Href.class)) {//@Href
+		} else if (field.isAnnotationPresent(Href.class)) {// @Href
 			Href href = field.getAnnotation(Href.class);
 			String url = $href(selector, href.value());
 			return url;
-		} else if(field.isAnnotationPresent(Attr.class)) {//@Attr
+		} else if (field.isAnnotationPresent(Attr.class)) {// @Attr
 			Attr attr = field.getAnnotation(Attr.class);
 			String name = attr.value();
 			return Conversion.getValue(field.getType(), $attr(selector, name));
-		} else {//@Html
+		} else {// @Html
 			return $html(selector);
 		}
 	}
-	
+
 	public List<Object> $basicList(String selector, Field field) throws Exception {
 		List<Object> list = new ArrayList<Object>();
 		Elements els = $(selector);
-		for(Element el : els) {
-			if(field.isAnnotationPresent(Text.class)) {//@Text
+		for (Element el : els) {
+			if (field.isAnnotationPresent(Text.class)) {// @Text
 				Text text = field.getAnnotation(Text.class);
 				list.add(Conversion.getValue(field.getType(), $text(el, text.own())));
-			} else if(field.isAnnotationPresent(Image.class)) {//@Image
+			} else if (field.isAnnotationPresent(Image.class)) {// @Image
 				Image image = field.getAnnotation(Image.class);
 				String imageSrc = $image(el, image.value());
 				String localPath = DownloadImage.download(image.download(), imageSrc);
-				if(StringUtils.isNotEmpty(localPath)) {
+				if (StringUtils.isNotEmpty(localPath)) {
 					list.add(localPath);
 				}
 				list.add(imageSrc);
-			} else if(field.isAnnotationPresent(Href.class)) {//@Href
+			} else if (field.isAnnotationPresent(Href.class)) {// @Href
 				Href href = field.getAnnotation(Href.class);
 				String url = $href(el, href.value());
 				list.add(url);
-			} else if(field.isAnnotationPresent(Attr.class)) {//@Attr
+			} else if (field.isAnnotationPresent(Attr.class)) {// @Attr
 				Attr attr = field.getAnnotation(Attr.class);
 				String name = attr.value();
 				list.add(Conversion.getValue(field.getType(), $attr(el, name)));
-			} else {//@Html
+			} else if (field.isAnnotationPresent(Html.class)) {// @Html
+				Html attr = field.getAnnotation(Html.class);
+				list.add(attr.isOuter() ? el.outerHtml() : el.html());
+			} else {// Other
 				list.add(el.html());
 			}
 		}
 		return list;
 	}
-	
-	public SpiderBean $bean(String selector, HttpRequest request, Class<? extends SpiderBean> clazz) throws RenderException {
+
+	public SpiderBean $bean(String selector, HttpRequest request, Class<? extends SpiderBean> clazz)
+			throws RenderException {
 		String subHtml = $html(selector);
-		//table
+		// table
 		HttpResponse subResponse = HttpResponse.createSimple(subHtml);
 		Render render = RenderContext.getRender(RenderType.HTML);
 		return render.inject(clazz, request, subResponse);
 	}
-	
-	public List<SpiderBean> $beanList(String selector, HttpRequest request, Class<? extends SpiderBean> clazz) throws RenderException {
+
+	public List<SpiderBean> $beanList(String selector, HttpRequest request, Class<? extends SpiderBean> clazz)
+			throws RenderException {
 		List<SpiderBean> list = new ArrayList<SpiderBean>();
 		List<String> els = $list(selector);
-		for(String el : els) {
-			//table
+		for (String el : els) {
+			// table
 			HttpResponse subResponse = HttpResponse.createSimple(el);
 			Render render = RenderContext.getRender(RenderType.HTML);
 			SpiderBean subBean = render.inject(clazz, request, subResponse);
@@ -136,145 +142,145 @@ public class HtmlParser {
 
 	public Elements $(String selector) {
 		Elements elements = document.select(selector);
-		if(SpiderThreadLocal.get().getEngine().isDebug()) {
-			if(!selector.equalsIgnoreCase("script")) {
-				//log.debug("["+selector+"]--->["+elements+"]");
-				System.out.println("["+selector+"]--->["+elements+"]");
+		if (SpiderThreadLocal.get().getEngine().isDebug()) {
+			if (!selector.equalsIgnoreCase("script")) {
+				// log.debug("["+selector+"]--->["+elements+"]");
+				System.out.println("[" + selector + "]--->[" + elements + "]");
 			}
 		}
 		return elements;
 	}
-	
+
 	public Element $element(String selector) {
 		Elements elements = $(selector);
-		if(elements != null && elements.size() > 0) {
+		if (elements != null && elements.size() > 0) {
 			return elements.first();
 		}
 		return null;
 	}
-	
+
 	public List<String> $list(String selector) {
 		List<String> list = new ArrayList<String>();
 		Elements elements = $(selector);
-		if(elements != null) {
-			for(Element ele : elements) {
+		if (elements != null) {
+			for (Element ele : elements) {
 				list.add(ele.outerHtml());
 			}
 		}
 		return list;
 	}
-	
+
 	public String $html(String selector) {
 		Elements elements = $(selector);
-		if(elements != null) {
+		if (elements != null) {
 			return elements.html();
 		}
 		return null;
 	}
-	
+
 	public String $text(Element element, boolean own) {
-		if(element == null) {
+		if (element == null) {
 			return null;
 		}
 		String text = "";
-		if(own) {
+		if (own) {
 			text = element.ownText();
 		} else {
 			text = element.text();
 		}
-		//替换掉空格信息
+		// 替换掉空格信息
 		return StringUtils.replace(text, "\u00A0", "");
 	}
-	
+
 	public String $text(String selector, boolean own) {
 		Element element = $element(selector);
-		if(element != null) {
+		if (element != null) {
 			return $text(element, own);
 		}
 		return null;
 	}
-	
+
 	public String $attr(Element element, String attr) {
-		if(element == null) {
+		if (element == null) {
 			return null;
 		}
 		return element.attr(attr);
 	}
-	
+
 	public String $attr(String selector, String attr) {
 		Element element = $element(selector);
-		if(element == null) {
+		if (element == null) {
 			return null;
 		}
 		return element.attr(attr);
 	}
-	
+
 	public String $href(Element href, String attr) {
-		if(href == null) {
+		if (href == null) {
 			return null;
 		}
 		return href.absUrl(attr);
 	}
-	
+
 	public String $href(Element href, String... attrs) {
-		if(href == null) {
+		if (href == null) {
 			return null;
 		}
-		for(String attr : attrs) {
+		for (String attr : attrs) {
 			String value = $href(href, attr);
-			if(StringUtils.isNotEmpty(value)) {
+			if (StringUtils.isNotEmpty(value)) {
 				return value;
 			}
 		}
 		return $href(href, "href");
 	}
-	
+
 	public String $href(String selector, String attr) {
 		return $href($element(selector), attr);
 	}
-	
+
 	public String $href(String selector, String... attrs) {
 		return $href($element(selector), attrs);
 	}
-	
+
 	public String $image(Element img, String attr) {
-		if(img == null) {
+		if (img == null) {
 			return null;
 		}
 		return img.absUrl(attr);
 	}
-	
+
 	public String $image(Element img, String... attrs) {
-		if(img == null) {
+		if (img == null) {
 			return null;
 		}
-		for(String attr : attrs) {
+		for (String attr : attrs) {
 			String value = $image(img, attr);
-			if(StringUtils.isNotEmpty(value)) {
+			if (StringUtils.isNotEmpty(value)) {
 				return value;
 			}
 		}
 		return $image(img, "src");
 	}
-	
+
 	public String $image(String selector, String attr) {
 		return $image($element(selector), attr);
 	}
-	
+
 	public String $image(String selector, String... attrs) {
 		return $image($element(selector), attrs);
 	}
-	
+
 	public void setLogClass(Class<? extends SpiderBean> spiderBeanClass) {
 		log = LogFactory.getLog(spiderBeanClass);
 	}
-	
+
 	private boolean isTable(String content) {
-		if(!StringUtils.contains(content, "</html>")) {
+		if (!StringUtils.contains(content, "</html>")) {
 			String rege = "<\\s*(tr|td|th)[\\s\\S]+";
 			Pattern pattern = Pattern.compile(rege);
 			Matcher matcher = pattern.matcher(content);
-			if(matcher.matches()) {
+			if (matcher.matches()) {
 				return true;
 			}
 		}


### PR DESCRIPTION
       比如有时候为了获取 a 标签的全部内容，使用HTML 注解时 获取到的是a标签的内容，并不能获取到A标签本身。
 
      在Html注解中添加了一个属性，用于获取外部HTML内容，如果不指定默认获取内部HTML内容。      