### PR TITLE
Add link to tool comparison resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ![ci](https://api.travis-ci.org/xtuhcy/gecco.svg?branch=master)
 ![maven](https://img.shields.io/maven-central/v/com.geccocrawler/gecco.svg?style=flat-square)
 
-##What is Gecco
+## What is Gecco
 Gecco is a easy to use lightweight web crawler developed with java language.Gecco integriert jsoup, httpclient, fastjson, spring, htmlunit, redission ausgezeichneten framework,Let you only need to configure a number of jQuery style selector can be very quick to write a crawler.Gecco framework has excellent scalability, the framework based on the principle of open and close design, to modify the closure, the expansion of open.At the same time Gecco is based on a very open MIT open source protocol, whether you are a user or want to jointly improve the Gecco developer, welcome to request pull.If you like the crawler framework,please [star or fork](https://github.com/xtuhcy/gecco)!
 
 * [中文说明](https://github.com/xtuhcy/gecco/blob/master/README_CN.md)
 
 * [中文参考手册](http://www.geccocrawler.com/)
 
-##Main features
+## Main features
 
 * [x] Easy to use, use jQuery style selector to extract elements
 * [x] Support for asynchronous Ajax requests in the page
@@ -20,11 +20,11 @@ Gecco is a easy to use lightweight web crawler developed with java language.Gecc
 * [x] Support download UserAgent random selection
 * [x] Support the download proxy server randomly selected
 
-##Framework overview
+## Framework overview
 ![架构图](https://raw.githubusercontent.com/xtuhcy/gecco/master/doc/%E6%9E%B6%E6%9E%84%E5%9B%BE.jpg)
 
-##Download
-###Download via Maven
+## Download
+### Download via Maven
 
 ```xml
 <dependency>
@@ -36,10 +36,10 @@ Gecco is a easy to use lightweight web crawler developed with java language.Gecc
 
 ![maven](https://img.shields.io/maven-central/v/com.geccocrawler/gecco.svg?style=flat-square)
 
-###Dependent project
+### Dependent project
 httpclient，jsoup，fastjson，reflections，cglib，rhino，log4j，jmxutils，commons-lang3
 
-##Quick start
+## Quick start
 
 ```java
 @Gecco(matchUrl="https://github.com/{user}/{project}", pipelines="consolePipeline")
@@ -130,7 +130,7 @@ public class MyGithub implements HtmlBean {
 }
 ```
 
-##DynamicGecco
+## DynamicGecco
 The purpose of DynamicGecco is to implement the runtime configuration of the crawl rule without defining the SpiderBean.In fact, the principle is the use of byte code programming, dynamic generation of SpiderBean, but also through the custom GeccoClassLoader to achieve the rule of hot deployment.Below is a simple Demo, more complex Demo can refer to the example below com.geccocrawler.gecco.demo.dynamic.
 
 The following code implements the runtime configuration of the crawl rule:
@@ -153,7 +153,7 @@ The following code implements the runtime configuration of the crawl rule:
 
 You can see that the DynamicGecco way compared to the traditional way of annotation code greatly reduced, and a very cool point is DynamicGecco to support the operation of the definition and modification of rules.
 
-##Demo
+## Demo
 [教您使用java爬虫gecco抓取JD全部商品信息（一）](http://my.oschina.net/u/2336761/blog/620158)
 
 [教您使用java爬虫gecco抓取JD全部商品信息（二）](http://my.oschina.net/u/2336761/blog/620827)
@@ -168,10 +168,16 @@ You can see that the DynamicGecco way compared to the traditional way of annotat
 
 [典型案例—闲逛APP](http://www.geccocrawler.com/xg/)
 
-##Contact and communication
+## Similar Tool Comparison
+
+A list of similar tools and how they compare is available here:
+
+[Web Archiving Software Comparision](https://github.com/archivers-space/research/tree/master/web_archiving)
+
+## Contact and communication
 
 - blog：http://my.oschina.net/u/2336761/blog
 - email：xtuhcy@163.com
 
-##License
+## License
 Please follow the open source protocol [MIT](https://raw.githubusercontent.com/xtuhcy/gecco/master/LICENSE)!


### PR DESCRIPTION
Hi there!

I'm working with a group called [EDGI](http://envirodatagov.org/). We are working with archive.org and IPFS to help archive environment and scientific data. In order to orient ourselves, we've started maintaining a resource to help us understand the tool landscape.

Might you be interested in helping us to maintain this resource, and perhaps add a link to your README? If so, I'd be happy to provide you collaborator access (though most of the data is in a publicly-edittable spreadsheet) :)

Looking forward to hopefully working together to build a shared resource!

cc: @mhucka