### PR TITLE
可以指定是否强制使用自定义的编码方式

### DIFF
--- a/src/main/java/com/geccocrawler/gecco/downloader/HttpClientDownloader.java
+++ b/src/main/java/com/geccocrawler/gecco/downloader/HttpClientDownloader.java
@@ -207,9 +207,11 @@ public class HttpClientDownloader extends AbstractDownloader {
 			}
 			return resp;
 		} catch(ConnectTimeoutException | SocketTimeoutException e) {
+			if(proxy != null) {
+				proxys.failure(proxy.getHostName(), proxy.getPort());
+			}
 			throw new DownloadTimeoutException(e);
 		} catch(IOException e) {
-			//超时等
 			if(proxy != null) {
 				proxys.failure(proxy.getHostName(), proxy.getPort());
 			}

--- a/src/main/java/com/geccocrawler/gecco/downloader/HttpClientDownloader.java
+++ b/src/main/java/com/geccocrawler/gecco/downloader/HttpClientDownloader.java
@@ -189,7 +189,7 @@ public class HttpClientDownloader extends AbstractDownloader {
 				}
 				resp.setContentType(contentType);
 				if(!isImage(contentType)) { 
-					String charset = getCharset(request.getCharset(), contentType);
+					String charset = request.isForceUseCharset() ? request.getCharset():getCharset(request.getCharset(), contentType);
 					resp.setCharset(charset);
 					//String content = EntityUtils.toString(responseEntity, charset);
 					String content = getContent(raw, responseEntity.getContentLength(), charset);

--- a/src/main/java/com/geccocrawler/gecco/request/AbstractHttpRequest.java
+++ b/src/main/java/com/geccocrawler/gecco/request/AbstractHttpRequest.java
@@ -15,6 +15,8 @@ public abstract class AbstractHttpRequest implements HttpRequest, Comparable<Htt
 
 	private String url;
 	
+	private boolean forceUseCharset = false;
+	
 	private String charset;
 	
 	private Map<String, String> parameters;
@@ -120,6 +122,16 @@ public abstract class AbstractHttpRequest implements HttpRequest, Comparable<Htt
 	@Override
 	public Map<String, String> getParameters() {
 		return parameters;
+	}
+	
+	@Override
+	public void setForceUseCharset(boolean forceUseCharset) {
+		this.forceUseCharset = forceUseCharset;
+	}
+
+	@Override
+	public boolean isForceUseCharset() {
+		return forceUseCharset;
 	}
 
 	@Override

--- a/src/main/java/com/geccocrawler/gecco/request/HttpRequest.java
+++ b/src/main/java/com/geccocrawler/gecco/request/HttpRequest.java
@@ -28,6 +28,10 @@ public interface HttpRequest extends Cloneable {
 	
 	public void setCharset(String charset);
 	
+	public void setForceUseCharset(boolean forceUseCharset);
+	
+	public boolean isForceUseCharset();
+	
 	public HttpRequest subRequest(String url);
 	
 	public Map<String, String> getCookies();


### PR DESCRIPTION
有使用页面头为Content-Type: text/html，则默认编码使用UTF-8，设置强制编码可以不使用默认错误的编码方式