### PR TITLE
修改JsonFieldRender的spiderBeanListRender方法的src转换异常

### DIFF
--- a/src/main/java/com/geccocrawler/gecco/spider/render/json/JsonFieldRender.java
+++ b/src/main/java/com/geccocrawler/gecco/spider/render/json/JsonFieldRender.java
@@ -104,7 +104,7 @@ public class JsonFieldRender implements FieldRender {
 	@SuppressWarnings({ "rawtypes" })
 	private List<SpiderBean> spiderBeanListRender(Object src, Class genericClass, HttpRequest request) {
 		List<SpiderBean> list = new ArrayList<SpiderBean>();
-		JSONArray ja = (JSONArray) src;
+		Iterable ja = (Iterable) src;
 		for (Object jo : ja) {
 			if(jo != null) {
 				SpiderBean subBean = this.spiderBeanRender(jo, genericClass, request);


### PR DESCRIPTION
在spiderBeanListRender方法中，直接将src转换成JSONArray导致异常，因为src是ArrayList类型，无法转换成JSONArray。既然代码中只需要一个Iterable，干脆直接把src转换成Iterable就可以了。